### PR TITLE
Add tag pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,5 @@
     "minimist": "^1.2.6",
     "node-fetch": "^2.6.7",
     "parse-link-header": "^2.0.0"
-  },
-  "packageManager": "yarn@4.5.0+sha512.837566d24eec14ec0f5f1411adb544e892b3454255e61fdef8fd05f3429480102806bac7446bc9daff3896b01ae4b62d00096c7e989f1596f2af10b927532f39"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@balena/lint": "^5.4.2",
     "@types/jest": "^27.4.1",
     "@types/node-fetch": "^2.6.2",
+    "@types/parse-link-header": "^2.0.3",
     "husky": "^4.2.5",
     "jest": "^27.5.1",
     "lint-staged": "^11.0.0",
@@ -41,6 +42,8 @@
   },
   "dependencies": {
     "minimist": "^1.2.6",
-    "node-fetch": "^2.6.7"
-  }
+    "node-fetch": "^2.6.7",
+    "parse-link-header": "^2.0.0"
+  },
+  "packageManager": "yarn@4.5.0+sha512.837566d24eec14ec0f5f1411adb544e892b3454255e61fdef8fd05f3429480102806bac7446bc9daff3896b01ae4b62d00096c7e989f1596f2af10b927532f39"
 }

--- a/test/v2.aws.spec.ts
+++ b/test/v2.aws.spec.ts
@@ -1,0 +1,22 @@
+import * as assert from 'assert';
+
+import { RegistryClientV2 } from '../lib/registry-client-v2';
+import { parseRepo } from '../lib/common';
+
+// --- globals
+
+const REPO = 'public.ecr.aws/karpenter/karpenter';
+
+// --- Tests
+
+jest.setTimeout(20 * 1000);
+
+const repo = parseRepo(REPO);
+
+it('v2 public.ecr.aws / > 1000 tags', async () => {
+	const client = new RegistryClientV2({ repo });
+	const tags = await client.listTags();
+	assert(tags);
+	assert.equal(tags.name, repo.remoteName);
+	assert(tags.tags.length > 1000, 'not enough tags');
+});


### PR DESCRIPTION
Fixes #12.

Some tests fail, but the same ones fail in the master branch.

I needed to use this package in a project immediately, so I released this fork [to npm](https://www.npmjs.com/package/@makeshifter/oci-registry-client). If this repo is no longer maintained, hopefully someone might find that useful in the future.